### PR TITLE
Fixing the unit test method testURLEncoding

### DIFF
--- a/NetworkLayerTests/NetworkLayerTests.swift
+++ b/NetworkLayerTests/NetworkLayerTests.swift
@@ -27,18 +27,23 @@ class NetworkLayerTests: XCTestCase {
             return
         }
         var urlRequest = URLRequest(url: url)
-        let parameters: Parameters = ["UserID": 1,
-                          "Name": "Malcolm",
-                          "Email": "malcolm@network.com",
-                          "isCool": true]
+        let parameters: Parameters = [
+            "UserID": 1,
+            "Name": "Malcolm",
+            "Email": "malcolm@network.com",
+            "IsCool": true
+        ]
+        
         do {
-            try URLParameterEncoder.encode(urlRequest: &urlRequest, with: parameters)
+            let encoder = URLParameterEncoder()
+            try encoder.encode(urlRequest: &urlRequest, with: parameters)
             guard let fullURL = urlRequest.url else {
                 XCTAssertTrue(false, "urlRequest url is nil.")
                 return
             }
-            let expectedURL = "https:www.google.com/?Email=malcolm%2540network.com&isCool=true&Name=Malcolm&UserID=1"
-            XCTAssertEqual(fullURL.absoluteString, expectedURL)
+
+            let expectedURL = "https:www.google.com/?Name=Malcolm&Email=malcolm%2540network.com&UserID=1&IsCool=true"
+            XCTAssertEqual(fullURL.absoluteString.sorted(), expectedURL.sorted())
         }catch {
             
         }


### PR DESCRIPTION
- `URLParameterEncoder` init notation
- Fixed assert `XCTAssertEqual(fullURL.absoluteString.sorted(), expectedURL.sorted())`